### PR TITLE
fix: necessary libraries to successfully install xmlsec on m1

### DIFF
--- a/docker/pyenv/Dockerfile
+++ b/docker/pyenv/Dockerfile
@@ -14,6 +14,7 @@ FROM oar-metadata/ejsonschema
 RUN apt-get update && apt-get install -y python3-yaml curl wget less sudo zip   \
                                          p7zip-full ca-certificates git xmlsec1 \
                                          pkg-config build-essential libssl-dev  \
+                                         libxmlsec1-dev libxmlsec1-openssl \
                                          uwsgi-src python3-dev
 
 RUN pip install https://projects.unbit.it/downloads/uwsgi-lts.tar.gz


### PR DESCRIPTION
**_libxmlsec1-dev_** and **_libxmlsec1-openssl_** were necessary to successfully install the **_xmlsec_** package that was breaking the oar-auth-py/pyenv container's build on M1 macs.
